### PR TITLE
build: add action to upload verified build to artifacts

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -22,3 +22,12 @@ jobs:
 
       - name: Run Jest
         run: yarn run test
+        
+      - name: Archive verified build
+        uses: actions/upload-artifact@v3
+        with:
+          name: dist-verified
+          path: |
+            main.js
+            manifest.json
+            styles.css        


### PR DESCRIPTION
## Description

To make it simpler for people to test a build, they can go to a verified build and get the output made by the build system and validated.

## Motivation and Context

Allow users to test a build in PR along with the developers

## How has this been tested?

Via this PR. 

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] My change has adequate Unit Test coverage.

By creating a Pull Request you agree to our [Code of Conduct](https://github.com/schemar/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md). For further guidance on contributing please see [contributing guide](https://github.com/schemar/obsidian-tasks/blob/main/CONTRIBUTING.md)
